### PR TITLE
store shop_id upon successful access token request

### DIFF
--- a/app/controllers/betsy/response_listener_controller.rb
+++ b/app/controllers/betsy/response_listener_controller.rb
@@ -1,5 +1,6 @@
 class Betsy::ResponseListenerController < ApplicationController
   def etsy_response_listener
     Betsy.request_access_token(params)
+    Betsy.upsert_shop_id(params)
   end
 end

--- a/lib/betsy.rb
+++ b/lib/betsy.rb
@@ -106,6 +106,12 @@ module Betsy
     end
   end
 
+  def self.upsert_shop_id(params)
+    etsy_account = account_class.find_by(state: params[:state])
+    shop_id = User.get_me(etsy_account: etsy_account).shop_id
+    etsy_account.update(shop_id: shop_id)
+  end
+
   def self.account_class
     @@account_class ||= account_model.constantize
   end

--- a/lib/generators/betsy/templates/create_etsy_accounts.rb.tt
+++ b/lib/generators/betsy/templates/create_etsy_accounts.rb.tt
@@ -6,6 +6,7 @@ class CreateEtsyAccounts < ActiveRecord::Migration<%= migration_version %>
       t.integer :expires_in
       t.string :state
       t.string :code_verifier
+      t.integer :shop_id
       t.datetime :last_token_refresh
 
       t.timestamps


### PR DESCRIPTION
`shop_id` seems like a useful attribute to keep since it's used across many API endpoints.

This diff includes an additional method called `upsert_shop_id` which hits `https://openapi.etsy.com/v3/application/users/me`, takes the return value of `shop_id` and stores in user's EtsyAccount row.